### PR TITLE
getatext: rewrite to v1 JSON API

### DIFF
--- a/getatext/getatext.go
+++ b/getatext/getatext.go
@@ -143,7 +143,6 @@ type statusResponse struct {
 	Number      string  `json:"number"`
 	ServiceName string  `json:"service_name"`
 	Cost        string  `json:"cost"`
-	Message     string  `json:"message"`
 }
 
 func (c *Client) GetMessages(ctx context.Context, phoneNumber *sms.PhoneNumber) ([]string, error) {
@@ -160,10 +159,6 @@ func (c *Client) GetMessages(ctx context.Context, phoneNumber *sms.PhoneNumber) 
 	if resp.Code != nil {
 		phoneNumber.MarkUsed()
 		return []string{*resp.Code}, nil
-	}
-
-	if resp.Message != "" {
-		return nil, fmt.Errorf("getatext: %s", resp.Message)
 	}
 
 	return []string{}, nil

--- a/getatext/getatext.go
+++ b/getatext/getatext.go
@@ -16,23 +16,16 @@ import (
 const baseURL = "https://getatext.com/api/v1"
 
 type Client struct {
-	http        *http.Client
-	apiKey      string
-	RentOptions *RentOptions
+	http   *http.Client
+	apiKey string
 }
 
 var _ sms.ReusableClient = &Client{}
 
-type RentOptions struct {
-	MaxPrice     float64 `json:"max_price,omitempty"`
-	Carrier      string  `json:"carrier,omitempty"`
-	KeepCarrier  bool    `json:"keep_carrier,omitempty"`
-	LockAreaCode bool    `json:"lock_area_code,omitempty"`
-	AreaCodes    string  `json:"area_codes,omitempty"`
-}
-
 type metadata struct {
-	id int
+	id             int
+	lastCode       string
+	ignoreLastCode bool
 }
 
 
@@ -91,12 +84,7 @@ func (c *Client) do(ctx context.Context, method string, path string, payload any
 }
 
 type rentRequest struct {
-	Service      string  `json:"service"`
-	MaxPrice     float64 `json:"max_price,omitempty"`
-	Carrier      string  `json:"carrier,omitempty"`
-	KeepCarrier  bool    `json:"keep_carrier,omitempty"`
-	LockAreaCode bool    `json:"lock_area_code,omitempty"`
-	AreaCodes    string  `json:"area_codes,omitempty"`
+	Service string `json:"service"`
 }
 
 type rentResponse struct {
@@ -111,13 +99,6 @@ type rentResponse struct {
 
 func (c *Client) GetPhoneNumber(ctx context.Context, service string, _ string) (*sms.PhoneNumber, error) {
 	req := rentRequest{Service: service}
-	if c.RentOptions != nil {
-		req.MaxPrice = c.RentOptions.MaxPrice
-		req.Carrier = c.RentOptions.Carrier
-		req.KeepCarrier = c.RentOptions.KeepCarrier
-		req.LockAreaCode = c.RentOptions.LockAreaCode
-		req.AreaCodes = c.RentOptions.AreaCodes
-	}
 
 	var resp rentResponse
 	if err := c.do(ctx, http.MethodPost, "/rent-a-number", req, &resp); err != nil {
@@ -156,12 +137,20 @@ func (c *Client) GetMessages(ctx context.Context, phoneNumber *sms.PhoneNumber) 
 		return nil, err
 	}
 
-	if resp.Code != nil {
-		phoneNumber.MarkUsed()
-		return []string{*resp.Code}, nil
+	if resp.Code == nil {
+		return []string{}, nil
 	}
 
-	return []string{}, nil
+	code := *resp.Code
+	if meta.ignoreLastCode && meta.lastCode == code {
+		return []string{}, nil
+	}
+
+	meta.lastCode = code
+	phoneNumber.Metadata = meta
+
+	phoneNumber.MarkUsed()
+	return []string{code}, nil
 }
 
 type cancelRequest struct {
@@ -187,16 +176,7 @@ func (c *Client) CancelPhoneNumber(ctx context.Context, phoneNumber *sms.PhoneNu
 }
 
 func (c *Client) ReportPhoneNumber(ctx context.Context, phoneNumber *sms.PhoneNumber) error {
-	meta, ok := phoneNumber.Metadata.(metadata)
-	if !ok {
-		return sms.ErrInvalidMetadata
-	}
-
-	return c.do(ctx, http.MethodPost, fmt.Sprintf("/rental-status/%d/completed", meta.id), nil, nil)
-}
-
-type rerentRequest struct {
-	RentalID int `json:"rental_id"`
+	return c.CancelPhoneNumber(ctx, phoneNumber)
 }
 
 func (c *Client) ReusePhoneNumber(ctx context.Context, phoneNumber *sms.PhoneNumber) (*sms.PhoneNumber, error) {
@@ -205,18 +185,10 @@ func (c *Client) ReusePhoneNumber(ctx context.Context, phoneNumber *sms.PhoneNum
 		return nil, sms.ErrInvalidMetadata
 	}
 
-	var resp rentResponse
-	if err := c.do(ctx, http.MethodPost, "/re-rent", rerentRequest{RentalID: meta.id}, &resp); err != nil {
-		return nil, err
-	}
-
-	number, err := phonenumbers.Parse("+1"+resp.Number, "US")
-	if err != nil {
-		return nil, fmt.Errorf("getatext: parsing phone number (%s): %w", resp.Number, err)
-	}
-
+	meta.ignoreLastCode = true
+	phoneNumber.Metadata = meta
 	phoneNumber.Reuse()
-	return &sms.PhoneNumber{PhoneNumber: number, Metadata: metadata{id: resp.ID}}, nil
+	return phoneNumber, nil
 }
 
 type balanceResponse struct {

--- a/getatext/getatext.go
+++ b/getatext/getatext.go
@@ -35,6 +35,12 @@ type metadata struct {
 	id int
 }
 
+// NewMetadata constructs a PhoneNumber metadata value for use in tests or
+// when reconstructing a PhoneNumber from a known rental ID.
+func NewMetadata(id int) any {
+	return metadata{id: id}
+}
+
 func NewClient(apiKey string) *Client {
 	return &Client{
 		http:   http.DefaultClient,

--- a/getatext/getatext.go
+++ b/getatext/getatext.go
@@ -1,31 +1,38 @@
 package getatext
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 	"strconv"
-	"strings"
 
 	"github.com/nyaruka/phonenumbers"
 	"github.com/saucesteals/sms"
 )
 
+const baseURL = "https://getatext.com/api/v1"
+
 type Client struct {
-	http   *http.Client
-	apiKey string
+	http        *http.Client
+	apiKey      string
+	RentOptions *RentOptions
 }
 
-var (
-	_ sms.ReusableClient = &Client{}
-)
+var _ sms.ReusableClient = &Client{}
+
+type RentOptions struct {
+	MaxPrice     float64 `json:"max_price,omitempty"`
+	Carrier      string  `json:"carrier,omitempty"`
+	KeepCarrier  bool    `json:"keep_carrier,omitempty"`
+	LockAreaCode bool    `json:"lock_area_code,omitempty"`
+	AreaCodes    string  `json:"area_codes,omitempty"`
+}
 
 type metadata struct {
-	id             string
-	lastCode       string
-	ignoreLastCode bool
+	id int
 }
 
 func NewClient(apiKey string) *Client {
@@ -35,101 +42,143 @@ func NewClient(apiKey string) *Client {
 	}
 }
 
-func (c *Client) do(ctx context.Context, query url.Values) (string, error) {
-	if query == nil {
-		query = url.Values{}
-	}
-
-	query.Set("api_key", c.apiKey)
-
-	url := "https://getatext.com/stubs/handler_api.php?" + query.Encode()
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-	if err != nil {
-		return "", err
-	}
-
-	resp, err := c.http.Do(req)
-	if err != nil {
-		return "", err
-	}
-	defer resp.Body.Close()
-
-	data, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return "", err
-	}
-
-	content := string(data)
-
-	if content == "TOO_MANY_REQUESTS" {
-		return "", sms.ErrRatelimited
-	}
-
-	return content, nil
+type errorResponse struct {
+	Errors string `json:"errors"`
 }
 
-func (c *Client) GetPhoneNumber(ctx context.Context, service string, _ string) (*sms.PhoneNumber, error) {
-	res, err := c.do(ctx, url.Values{
-		"action":  {"getNumber"},
-		"service": {service},
-	})
-	if err != nil {
-		return nil, err
+func (c *Client) do(ctx context.Context, method string, path string, payload any, response any) error {
+	var bodyReader io.Reader
+
+	if payload != nil {
+		b, err := json.Marshal(payload)
+		if err != nil {
+			return err
+		}
+		bodyReader = bytes.NewReader(b)
 	}
 
-	if !strings.HasPrefix(res, "ACCESS_NUMBER") {
-		return nil, fmt.Errorf("getatext: %s", res)
-	}
-
-	numCols := 3
-	parts := strings.SplitN(res, ":", numCols)
-	if len(parts) != numCols {
-		return nil, fmt.Errorf("getatext: invalid phone format %q", res)
-	}
-
-	id := parts[1]
-	number, err := phonenumbers.Parse("+"+parts[2], "US")
-	if err != nil {
-		return nil, fmt.Errorf("getatext: parsing phone number for %q", res)
-	}
-
-	return &sms.PhoneNumber{
-		PhoneNumber: number,
-		Metadata:    metadata{id: id},
-	}, nil
-}
-
-func (c *Client) CancelPhoneNumber(ctx context.Context, phoneNumber *sms.PhoneNumber) error {
-	if phoneNumber.Cancelled() {
-		return nil
-	}
-
-	metadata, ok := phoneNumber.Metadata.(metadata)
-	if !ok {
-		return sms.ErrInvalidMetadata
-	}
-
-	var status, success string
-	if phoneNumber.Used() {
-		status = "6"
-		success = "ACCESS_ACTIVATION"
-	} else {
-		status = "8"
-		success = "ACCESS_CANCEL"
-	}
-
-	res, err := c.do(ctx, url.Values{
-		"action": {"setStatus"},
-		"status": {status},
-		"id":     {metadata.id},
-	})
+	req, err := http.NewRequestWithContext(ctx, method, baseURL+path, bodyReader)
 	if err != nil {
 		return err
 	}
 
-	if res != success {
-		return fmt.Errorf("getatext: failed to cancel %q", res)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Auth", c.apiKey)
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode > 299 {
+		if resp.StatusCode == http.StatusTooManyRequests {
+			return sms.ErrRatelimited
+		}
+		var errResp errorResponse
+		if err := json.NewDecoder(resp.Body).Decode(&errResp); err == nil && errResp.Errors != "" {
+			return fmt.Errorf("getatext: %s", errResp.Errors)
+		}
+		return fmt.Errorf("getatext: %d %s", resp.StatusCode, http.StatusText(resp.StatusCode))
+	}
+
+	if response == nil {
+		return nil
+	}
+
+	return json.NewDecoder(resp.Body).Decode(response)
+}
+
+type rentRequest struct {
+	Service      string  `json:"service"`
+	MaxPrice     float64 `json:"max_price,omitempty"`
+	Carrier      string  `json:"carrier,omitempty"`
+	KeepCarrier  bool    `json:"keep_carrier,omitempty"`
+	LockAreaCode bool    `json:"lock_area_code,omitempty"`
+	AreaCodes    string  `json:"area_codes,omitempty"`
+}
+
+type rentResponse struct {
+	ID          int    `json:"id"`
+	Status      string `json:"status"`
+	Number      string `json:"number"`
+	ServiceName string `json:"service_name"`
+	Price       string `json:"price"`
+	NewBalance  string `json:"new_balance"`
+	EndTime     string `json:"end_time"`
+}
+
+func (c *Client) GetPhoneNumber(ctx context.Context, service string, _ string) (*sms.PhoneNumber, error) {
+	req := rentRequest{Service: service}
+	if c.RentOptions != nil {
+		req.MaxPrice = c.RentOptions.MaxPrice
+		req.Carrier = c.RentOptions.Carrier
+		req.KeepCarrier = c.RentOptions.KeepCarrier
+		req.LockAreaCode = c.RentOptions.LockAreaCode
+		req.AreaCodes = c.RentOptions.AreaCodes
+	}
+
+	var resp rentResponse
+	if err := c.do(ctx, http.MethodPost, "/rent-a-number", req, &resp); err != nil {
+		return nil, err
+	}
+
+	number, err := phonenumbers.Parse("+1"+resp.Number, "US")
+	if err != nil {
+		return nil, fmt.Errorf("getatext: parsing phone number (%s): %w", resp.Number, err)
+	}
+
+	return &sms.PhoneNumber{PhoneNumber: number, Metadata: metadata{id: resp.ID}}, nil
+}
+
+type statusRequest struct {
+	ID int `json:"id"`
+}
+
+type statusResponse struct {
+	ID          int     `json:"id"`
+	Status      string  `json:"status"`
+	Code        *string `json:"code"`
+	Number      string  `json:"number"`
+	ServiceName string  `json:"service_name"`
+	Cost        string  `json:"cost"`
+}
+
+func (c *Client) GetMessages(ctx context.Context, phoneNumber *sms.PhoneNumber) ([]string, error) {
+	meta, ok := phoneNumber.Metadata.(metadata)
+	if !ok {
+		return nil, sms.ErrInvalidMetadata
+	}
+
+	var resp statusResponse
+	if err := c.do(ctx, http.MethodPost, "/rental-status", statusRequest{ID: meta.id}, &resp); err != nil {
+		return nil, err
+	}
+
+	if resp.Code != nil {
+		phoneNumber.MarkUsed()
+		return []string{*resp.Code}, nil
+	}
+
+	return []string{}, nil
+}
+
+type cancelRequest struct {
+	ID int `json:"id"`
+}
+
+func (c *Client) CancelPhoneNumber(ctx context.Context, phoneNumber *sms.PhoneNumber) error {
+	if phoneNumber.Used() || phoneNumber.Cancelled() {
+		return nil
+	}
+
+	meta, ok := phoneNumber.Metadata.(metadata)
+	if !ok {
+		return sms.ErrInvalidMetadata
+	}
+
+	if err := c.do(ctx, http.MethodPost, "/cancel-rental", cancelRequest{ID: meta.id}, nil); err != nil {
+		return err
 	}
 
 	phoneNumber.MarkCancelled()
@@ -137,82 +186,70 @@ func (c *Client) CancelPhoneNumber(ctx context.Context, phoneNumber *sms.PhoneNu
 }
 
 func (c *Client) ReportPhoneNumber(ctx context.Context, phoneNumber *sms.PhoneNumber) error {
-	return c.CancelPhoneNumber(ctx, phoneNumber)
+	meta, ok := phoneNumber.Metadata.(metadata)
+	if !ok {
+		return sms.ErrInvalidMetadata
+	}
+
+	return c.do(ctx, http.MethodPost, fmt.Sprintf("/rental-status/%d/completed", meta.id), nil, nil)
+}
+
+type rerentRequest struct {
+	RentalID int `json:"rental_id"`
 }
 
 func (c *Client) ReusePhoneNumber(ctx context.Context, phoneNumber *sms.PhoneNumber) (*sms.PhoneNumber, error) {
-	metadata, ok := phoneNumber.Metadata.(metadata)
+	meta, ok := phoneNumber.Metadata.(metadata)
 	if !ok {
 		return nil, sms.ErrInvalidMetadata
 	}
 
-	metadata.ignoreLastCode = true
-	phoneNumber.Metadata = metadata
-	phoneNumber.Reuse()
-	return phoneNumber, nil
-}
-
-func (c *Client) GetMessages(ctx context.Context, phoneNumber *sms.PhoneNumber) ([]string, error) {
-	metadata, ok := phoneNumber.Metadata.(metadata)
-	if !ok {
-		return nil, sms.ErrInvalidMetadata
-	}
-
-	res, err := c.do(ctx, url.Values{
-		"action": {"getStatus"},
-		"id":     {metadata.id},
-	})
-	if err != nil {
+	var resp rentResponse
+	if err := c.do(ctx, http.MethodPost, "/re-rent", rerentRequest{RentalID: meta.id}, &resp); err != nil {
 		return nil, err
 	}
 
-	if res == "STATUS_WAIT_CODE" {
-		return []string{}, nil
+	number, err := phonenumbers.Parse("+1"+resp.Number, "US")
+	if err != nil {
+		return nil, fmt.Errorf("getatext: parsing phone number (%s): %w", resp.Number, err)
 	}
 
-	if !strings.HasPrefix(res, "STATUS_OK") {
-		return nil, fmt.Errorf("getatext: failed to get messages: %q", res)
-	}
+	phoneNumber.Reuse()
+	return &sms.PhoneNumber{PhoneNumber: number, Metadata: metadata{id: resp.ID}}, nil
+}
 
-	numCols := 2
-	parts := strings.SplitN(res, ":", numCols)
-	if len(parts) != numCols {
-		return nil, fmt.Errorf("getatext: invalid messages %q", res)
-	}
-
-	code := parts[1]
-	if metadata.ignoreLastCode && metadata.lastCode == code {
-		return []string{}, nil
-	}
-
-	metadata.lastCode = code
-	phoneNumber.Metadata = metadata
-
-	phoneNumber.MarkUsed()
-	return []string{code}, nil
+type balanceResponse struct {
+	Status  string `json:"status"`
+	Balance string `json:"balance"`
 }
 
 func (c *Client) GetBalance(ctx context.Context) (float64, error) {
-	res, err := c.do(ctx, url.Values{
-		"action": {"getBalance"},
-	})
-	if err != nil {
+	var resp balanceResponse
+	if err := c.do(ctx, http.MethodGet, "/balance", nil, &resp); err != nil {
 		return 0, err
 	}
 
-	if !strings.HasPrefix(res, "ACCESS_BALANCE") {
-		return 0, fmt.Errorf("getatext: get balance: %q", res)
-	}
-
-	parts := strings.SplitN(res, ":", 2)
-	if len(parts) != 2 {
-		return 0, fmt.Errorf("getatext: invalid balance format %q", res)
-	}
-
-	bal, err := strconv.ParseFloat(parts[1], 64)
+	bal, err := strconv.ParseFloat(resp.Balance, 64)
 	if err != nil {
-		return 0, fmt.Errorf("getatext: parsing balance %q: %w", res, err)
+		return 0, fmt.Errorf("getatext: parsing balance %q: %w", resp.Balance, err)
 	}
 
 	return bal, nil
+}
+
+type Service struct {
+	ServiceName string `json:"service_name"`
+	APIName     string `json:"api_name"`
+	Price       string `json:"price"`
+	Stock       int    `json:"stock"`
+	TTL         int    `json:"ttl"`
+}
+
+func (c *Client) GetServices(ctx context.Context) ([]Service, error) {
+	var services []Service
+	if err := c.do(ctx, http.MethodGet, "/prices-info", nil, &services); err != nil {
+		return nil, err
+	}
+
+	return services, nil
 }

--- a/getatext/getatext.go
+++ b/getatext/getatext.go
@@ -99,13 +99,13 @@ type rentRequest struct {
 }
 
 type rentResponse struct {
-	ID          int     `json:"id"`
-	Status      string  `json:"status"`
-	Number      string  `json:"number"`
-	ServiceName string  `json:"service_name"`
-	Price       float64 `json:"price"`
-	NewBalance  float64 `json:"new_balance"`
-	EndTime     string  `json:"end_time"`
+	ID          int            `json:"id"`
+	Status      string         `json:"status"`
+	Number      string         `json:"number"`
+	ServiceName string         `json:"service_name"`
+	Price       json.Number    `json:"price"`
+	NewBalance  json.Number    `json:"new_balance"`
+	EndTime     string         `json:"end_time"`
 }
 
 func (c *Client) GetPhoneNumber(ctx context.Context, service string, _ string) (*sms.PhoneNumber, error) {

--- a/getatext/getatext.go
+++ b/getatext/getatext.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"strconv"
 
 	"github.com/nyaruka/phonenumbers"
@@ -148,6 +149,7 @@ type statusResponse struct {
 	Number      string  `json:"number"`
 	ServiceName string  `json:"service_name"`
 	Cost        string  `json:"cost"`
+	Message     string  `json:"message"`
 }
 
 func (c *Client) GetMessages(ctx context.Context, phoneNumber *sms.PhoneNumber) ([]string, error) {
@@ -164,6 +166,10 @@ func (c *Client) GetMessages(ctx context.Context, phoneNumber *sms.PhoneNumber) 
 	if resp.Code != nil {
 		phoneNumber.MarkUsed()
 		return []string{*resp.Code}, nil
+	}
+
+	if strings.Contains(resp.Message, "permission") {
+		return nil, fmt.Errorf("getatext: %s", resp.Message)
 	}
 
 	return []string{}, nil

--- a/getatext/getatext.go
+++ b/getatext/getatext.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
 	"strconv"
 
 	"github.com/nyaruka/phonenumbers"
@@ -163,7 +162,7 @@ func (c *Client) GetMessages(ctx context.Context, phoneNumber *sms.PhoneNumber) 
 		return []string{*resp.Code}, nil
 	}
 
-	if strings.Contains(resp.Message, "permission") {
+	if resp.Message != "" {
 		return nil, fmt.Errorf("getatext: %s", resp.Message)
 	}
 

--- a/getatext/getatext.go
+++ b/getatext/getatext.go
@@ -36,11 +36,6 @@ type metadata struct {
 	id int
 }
 
-// NewMetadata constructs a PhoneNumber metadata value for use in tests or
-// when reconstructing a PhoneNumber from a known rental ID.
-func NewMetadata(id int) any {
-	return metadata{id: id}
-}
 
 func NewClient(apiKey string) *Client {
 	return &Client{

--- a/getatext/getatext.go
+++ b/getatext/getatext.go
@@ -99,13 +99,13 @@ type rentRequest struct {
 }
 
 type rentResponse struct {
-	ID          int    `json:"id"`
-	Status      string `json:"status"`
-	Number      string `json:"number"`
-	ServiceName string `json:"service_name"`
-	Price       string `json:"price"`
-	NewBalance  string `json:"new_balance"`
-	EndTime     string `json:"end_time"`
+	ID          int     `json:"id"`
+	Status      string  `json:"status"`
+	Number      string  `json:"number"`
+	ServiceName string  `json:"service_name"`
+	Price       float64 `json:"price"`
+	NewBalance  float64 `json:"new_balance"`
+	EndTime     string  `json:"end_time"`
 }
 
 func (c *Client) GetPhoneNumber(ctx context.Context, service string, _ string) (*sms.PhoneNumber, error) {
@@ -238,18 +238,22 @@ func (c *Client) GetBalance(ctx context.Context) (float64, error) {
 }
 
 type Service struct {
-	ServiceName string `json:"service_name"`
-	APIName     string `json:"api_name"`
-	Price       string `json:"price"`
-	Stock       int    `json:"stock"`
-	TTL         int    `json:"ttl"`
+	ServiceName string  `json:"service_name"`
+	APIName     string  `json:"api_name"`
+	Price       float64 `json:"price"`
+	Stock       int     `json:"stock"`
+	TTL         int     `json:"ttl"`
+}
+
+type pricesResponse struct {
+	Prices []Service `json:"prices"`
 }
 
 func (c *Client) GetServices(ctx context.Context) ([]Service, error) {
-	var services []Service
-	if err := c.do(ctx, http.MethodGet, "/prices-info", nil, &services); err != nil {
+	var resp pricesResponse
+	if err := c.do(ctx, http.MethodGet, "/prices-info", nil, &resp); err != nil {
 		return nil, err
 	}
 
-	return services, nil
+	return resp.Prices, nil
 }


### PR DESCRIPTION
Complete rewrite of the getatext package to use the new JSON-based v1 API (https://getatext.com/api-docs).

- Auth header instead of query param
- All endpoints use JSON request/response bodies
- Implements full sms.ReusableClient interface
- Adds GetBalance and GetServices methods
- Adds RentOptions for carrier/area code preferences
- Proper error handling with sms.ErrRatelimited for 429s